### PR TITLE
Fixed failed to compile error

### DIFF
--- a/app/components/ParticlesEffect.tsx
+++ b/app/components/ParticlesEffect.tsx
@@ -5,8 +5,6 @@ import Particles, { initParticlesEngine } from "@tsparticles/react";
 import {
   type Container,
   type ISourceOptions,
-  MoveDirection,
-  OutMode,
 } from "@tsparticles/engine";
 // import { loadAll } from "@tsparticles/all"; // if you are going to use `loadAll`, install the "@tsparticles/all" package too.
 // import { loadFull } from "tsparticles"; // if you are going to use `loadFull`, install the "tsparticles" package too.


### PR DESCRIPTION
8:3  Error: 'MoveDirection' is defined but never used.  @typescript-eslint/no-unused-vars
9:3  Error: 'OutMode' is defined but never used.  @typescript-eslint/no-unused-vars